### PR TITLE
refactor: move port config inside a service dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@
     Here's an example config file:
     ```
     {
-        "port" : 8000,
         "api_call_intervals" : 2,
         "log_level" : "INFO",
         "services" : {
             "splunk" : {
                 "service_class" : "SplunkApi",
                 "service_module" : "splunk_api",
+                "port" : 8000,
                 "api_url" : "https://api.victorops.com/api-reporting/v2/incidents",
                 "prometheus_metrics_mapping" : {
                     "counter" : [

--- a/collectington/config.py
+++ b/collectington/config.py
@@ -133,7 +133,7 @@ def validate_service(service_name, service):
 
 def validate_metrics_mapping(service_name, metrics_mapping):
     """Test that the metrics mapping of a service is valid."""
-    valid_metric_types = ["counter", "summary"]
+    valid_metric_types = ["counter", "summary", "histogram", "gauge"]
 
     if not isinstance(metrics_mapping, dict):
         raise ValueError(

--- a/collectington/config.py
+++ b/collectington/config.py
@@ -122,7 +122,7 @@ def validate_service(service_name, service):
             f"Invalid config: all services should contain '{', '.join(expected_keys)}'"
         )
 
-    strings = ["service_class", "api_url", "secret_file_path"]
+    strings = ["service_class", "api_url"]
 
     for field in strings:
         if not isinstance(service[field], str):

--- a/collectington/config.py
+++ b/collectington/config.py
@@ -127,6 +127,8 @@ def validate_service(service_name, service):
     for field in strings:
         if not isinstance(service[field], str):
             raise ValueError(f"Invalid config: {field} fields should be a string")
+        if not isinstance(service["port"], int):
+            raise ValueError("Invalid config: port should be an integer")
 
     validate_metrics_mapping(service_name, service["prometheus_metrics_mapping"])
 

--- a/collectington/config.py
+++ b/collectington/config.py
@@ -127,8 +127,9 @@ def validate_service(service_name, service):
     for field in strings:
         if not isinstance(service[field], str):
             raise ValueError(f"Invalid config: {field} fields should be a string")
-        if not isinstance(service["port"], int):
-            raise ValueError("Invalid config: port should be an integer")
+
+    if not isinstance(service["port"], int):
+        raise ValueError("Invalid config: port should be an integer")
 
     validate_metrics_mapping(service_name, service["prometheus_metrics_mapping"])
 

--- a/collectington/config.py
+++ b/collectington/config.py
@@ -76,7 +76,6 @@ def get_service(config, service_name):
 def validate(config):
     """Test that provided json is a valid config."""
     if list(config.keys()) != [
-        "port",
         "api_call_intervals",
         "log_level",
         "services",
@@ -84,9 +83,6 @@ def validate(config):
         raise ValueError(
             "Invalid config: config should contain port, api_call_intervals, log_level, services"
         )
-
-    if not isinstance(config["port"], int):
-        raise ValueError("Invalid config: port should be an integer")
 
     if not isinstance(config["api_call_intervals"], int):
         raise ValueError("Invalid config: api_call_intervals should be an integer")

--- a/collectington/runner.py
+++ b/collectington/runner.py
@@ -85,8 +85,8 @@ if __name__ == "__main__":
     logger.info("Generating Prometheus Metric Instances")
     list_of_metric_instances = api_service.generate_prometheus_metric_instances()
 
-    logger.info("Setting up HTTP Server - PORT: %s", config["port"])
-    start_http_server(config["port"])
+    logger.info("Setting up HTTP Server - PORT: %s", config["services"][service_name]["port"])
+    start_http_server(config["services"][service_name]["port"])
 
     while True:
         run(api_service, list_of_metrics, list_of_metric_instances)

--- a/example/config.json
+++ b/example/config.json
@@ -1,11 +1,11 @@
 {
-   "port" : 8000,
    "api_call_intervals" : 2,
    "log_level" : "INFO",
    "services" : {
       "splunk" : {
          "service_class" : "SplunkApi",
          "service_module" : "splunk_api",
+         "port" : 8000,
          "api_url" : "https://api.victorops.com/api-reporting/v2/incidents",
          "prometheus_metrics_mapping" : {
             "counter" : [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=["prometheus-client", "termcolor", "pyfiglet", "requests"],
     scripts=["cton"],
     license="MIT",
-    version="0.1.2",
+    version="0.1.3",
     description="Collectington is a framework that allows any 3rd party API data to be sent to Prometheus",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- quick fix to ensure each service can run on a unique port until we have a new feature