### PR TITLE
fix(prometheus_metrics): fix broken prometheus metrics for dataplatformmonitoring

### DIFF
--- a/collectington/collectington_api.py
+++ b/collectington/collectington_api.py
@@ -168,12 +168,12 @@ class CollectingtonApi(ABC):
 
     def _init_p_method(self, p_method, api_metric):
         """Internal method to metric methods with labels only if they're provided."""
-        for service in self.config["services"]:
-            if (self.config["services"][service].get("prometheus_metric_labels") is not None
-                and api_metric in self.config["services"][service]["prometheus_metric_labels"]
-            ):
-                labels = self.config["services"][service]["prometheus_metric_labels"][api_metric]
-                return p_method(api_metric, api_metric, labels)
+        
+        if (self.config["services"][self.service_name].get("prometheus_metric_labels") is not None
+            and api_metric in self.config["services"][self.service_name]["prometheus_metric_labels"]
+        ):
+            labels = self.config["services"][self.service_name]["prometheus_metric_labels"][api_metric]
+            return p_method(api_metric, api_metric, labels)
 
         return p_method(api_metric, api_metric)
 
@@ -205,13 +205,12 @@ class CollectingtonApi(ABC):
         for p_instance in list_of_metric_instances:
             metric = str(p_instance).split(":")[1]
             labels_object = None
-            for service in self.config["services"]:
-                if (
-                    self.config["services"][service].get("prometheus_metric_labels") is not None
-                    and metric in self.config["services"][service]["prometheus_metric_labels"]
-                ):
-                    labels_object = self.config["services"][service]["prometheus_metric_labels"]
-                    break
+            if (
+                self.config["services"][self.service_name].get("prometheus_metric_labels") is not None
+                and metric in self.config["services"][self.service_name]["prometheus_metric_labels"]
+            ):
+                labels_object = self.config["services"][self.service_name]["prometheus_metric_labels"]
+                break
 
             if (labels_object is not None):
                 for labels_and_metric_object in service_metric_dict[metric]:

--- a/collectington/collectington_api.py
+++ b/collectington/collectington_api.py
@@ -204,17 +204,12 @@ class CollectingtonApi(ABC):
         """
         for p_instance in list_of_metric_instances:
             metric = str(p_instance).split(":")[1]
-            labels_object = None
             if (
                 self.config["services"][self.service_name].get("prometheus_metric_labels") is not None
                 and metric in self.config["services"][self.service_name]["prometheus_metric_labels"]
             ):
-                labels_object = self.config["services"][self.service_name]["prometheus_metric_labels"]
-                break
-
-            if (labels_object is not None):
                 for labels_and_metric_object in service_metric_dict[metric]:
-                    label_list = labels_object[metric]
+                    label_list = self.config["services"][self.service_name]["prometheus_metric_labels"][metric]
                     labels, val = self._split_labeled_metric_dict(labels_and_metric_object, label_list)
                     self._update_metric(p_instance.labels(*labels), val)
 


### PR DESCRIPTION
Fix dataplatformmonitoring prometheus metrics, which were broken after a major refactoring on Oct 18. The structure of the config JSON object had been changed, but the code had not been updated accordingly that looks for the prometheus metric labels inside the config JSON object.

Fixes: #2520 https://app.zenhub.com/workspaces/infrastructure-605e16028ad537001188e431/issues/homexlabs/hx-infrastructure/2520